### PR TITLE
regex: remove insensitive flag

### DIFF
--- a/WordReplacerApp.ts
+++ b/WordReplacerApp.ts
@@ -49,7 +49,7 @@ export class WordReplacerApp extends App  implements IPreMessageSentModify {
 
         Object.keys(this.filters).forEach((key) => {
             const filter = this.filters[key] || {};
-            text = text.replace(new RegExp(filter.search || '', 'gi'), filter.replace || '');
+            text = text.replace(new RegExp(filter.search || '', 'g'), filter.replace || '');
         });
 
         return builder.setText(text).getMessage();


### PR DESCRIPTION
I don't know if this flag was there on purpose but when trying the
regex in the example, I noticed `bug-123` was also modified.

I guess that's better to let the user pick what it wants. Here I
suggest to remove the `i` flag and the user can use `(BUG|bug)` to have
the same behaviour. But if needed, we could also add a config option.

BTW: thank you for sharing this nice simple plugin ;-)