### PR TITLE
regex: let the user pick the flags

### DIFF
--- a/WordReplacerApp.ts
+++ b/WordReplacerApp.ts
@@ -31,7 +31,7 @@ export class WordReplacerApp extends App  implements IPreMessageSentModify {
         await configuration.settings.provideSetting({
             id: 'filters',
             type: SettingType.STRING,
-            packageValue: '[{"search": "#(\\\\d+)", "replace": "[$&](https://www1.example.com/issues/$1)"}, {"search": "BUG-(\\\\d+)", "replace": "[$&](https://www2.example.com/issues/$1)"}]',
+            packageValue: '[{"search": "#(\\\\d+)", "replace": "[$&](https://www1.example.com/issues/$1)"}, {"search": "BUG-(\\\\d+)", "replace": "[$&](https://www2.example.com/issues/$1)", "flags": "gi"}]',
             required: true,
             public: false,
             multiline: true,
@@ -49,7 +49,7 @@ export class WordReplacerApp extends App  implements IPreMessageSentModify {
 
         Object.keys(this.filters).forEach((key) => {
             const filter = this.filters[key] || {};
-            text = text.replace(new RegExp(filter.search || '', 'gi'), filter.replace || '');
+            text = text.replace(new RegExp(filter.search || '', filter.flags || 'gi'), filter.replace || '');
         });
 
         return builder.setText(text).getMessage();


### PR DESCRIPTION
We might not want to use the insensitive case flag.

Leave it there by default but at least, there is a way to remove it or
use others like the multiline one.